### PR TITLE
Bumped `ff` version to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-derive-num"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["kwantam <kwantam@gmail.com>"]
 description = "Procedural macro library to add the Num trait to Field implementations for ff"
@@ -18,3 +18,6 @@ num-traits = "0.2"
 proc-macro2 = "1"
 quote = "1"
 syn = "1"
+
+[dev-dependencies]
+ff = { version = "0.13", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,10 @@ pub fn num_traits_num(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                 }
 
                 if s == "0" {
-                    return Ok(<Self as ::ff::Field>::zero());
+                    return Ok(<Self as ::ff::Field>::ZERO);
                 }
 
-                let mut res = <Self as ::ff::Field>::zero();
+                let mut res = <Self as ::ff::Field>::ZERO;
                 let radix = Self::from(r as u64);
                 let mut first_digit = true;
                 for c in s.chars() {
@@ -82,7 +82,7 @@ pub fn num_traits_num(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
         impl ::num_traits::Zero for #ident {
             fn zero() -> Self {
-                <Self as ::ff::Field>::zero()
+                <Self as ::ff::Field>::ZERO
             }
 
             fn is_zero(&self) -> bool {
@@ -92,11 +92,11 @@ pub fn num_traits_num(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
         impl ::num_traits::One for #ident {
             fn one() -> Self {
-                <Self as ::ff::Field>::one()
+                <Self as ::ff::Field>::ONE
             }
 
             fn is_one(&self) -> bool {
-                self == &<Self as ::ff::Field>::one()
+                self == &<Self as ::ff::Field>::ONE
             }
         }
 
@@ -129,7 +129,7 @@ pub fn num_traits_num(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                     panic!("divide by zero");
                 }
 
-                <Self as ::ff::Field>::zero()
+                <Self as ::ff::Field>::ZERO
             }
         }
 
@@ -142,7 +142,7 @@ pub fn num_traits_num(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                     panic!("divide by zero");
                 }
 
-                <Self as ::ff::Field>::zero()
+                <Self as ::ff::Field>::ZERO
             }
         }
 


### PR DESCRIPTION
new `ff` version switches from the previous `num_traits` standard of `zero()` and `one()`  function calls for primitives to constant-style `ZERO` and `ONE`.  